### PR TITLE
Turn off auto build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,6 @@ name: Build
 on:
   push:
     branches: [ trunk ]
-  schedule:
-    - cron: '15 0 * * *'
 
 jobs:
   update_codebase:


### PR DESCRIPTION
Disable building Share on a schedule while we prepare for the new
codebase schema.