### PR TITLE
Use dhall.releases._latest to reference latest release

### DIFF
--- a/init-share.md
+++ b/init-share.md
@@ -42,7 +42,7 @@ Pull in Unison projects to be hosted on Unison Share
 .> pull.without-history https://github.com/unisonweb/share-pre-oct-2021:.contrib.thoradam .thoradam
 .> pull.without-history https://github.com/ChrisPenner/unison-codebase:.share.file .chrispenner.file
 .> pull.without-history https://github.com/iamevn/unison-code:.trunk .iamevn
-.> pull.without-history https://github.com/hagl/dhall-unison:.dhall.releases._v1_share .hagl.dhall
+.> pull.without-history https://github.com/hagl/dhall-unison:.dhall.releases._latest .hagl.dhall
 .> pull.without-history https://github.com/vic/universe:.vic .vic
 ```
 

--- a/init-share.md
+++ b/init-share.md
@@ -67,6 +67,7 @@ _catalog = {{
 * stew.json
 * stew.parser
 * stew.json
+* hagl.dhall
 
 # Datatypes
 


### PR DESCRIPTION
The Dhall implementation for Unison now supports the whole Dhall language and passes most of the reference tests.
Would be good to get an updated version on Unison-Share.