### PR TITLE
Clean up build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -17,3 +17,6 @@ TMPDIR=build INSIDE_EMACS=1 ucm transcript init-share.md --save-codebase
 output=$(ls build | head -n 1)
 echo "output: $output"
 cp -R "build/${output}/.unison" .
+
+# This is a hacky check that we actually have stuff in the created codebase.
+echo "ls .unison.base" | INSIDE_EMACS=1 ucm --codebase . | grep "List"

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 echo ""
 echo "🚧 Rebuilding Unison Share from transcript 🚧"
 echo "---------------------------------------------"
@@ -9,6 +11,9 @@ rm -rf .unison
 rm -rf build
 
 mkdir build
-TMPDIR=build ucm transcript init-share.md --save-codebase
+# INSIDE_EMACS is a hack to make ucm not try to open up less since this is a
+# non-interactive script
+TMPDIR=build INSIDE_EMACS=1 ucm transcript init-share.md --save-codebase
 output=$(ls build | head -n 1)
-cp -R build/${output}/.unison .
+echo "output: $output"
+cp -R "build/${output}/.unison" .


### PR DESCRIPTION
It should stop when it hits an error. Unfortunately, I don't think that
this is going to make a difference, because it appears that `ucm
transcript` returns a `0` exit code even when there's a failure.

I also added a hack so that it doesn't try to open up less.